### PR TITLE
Fix for smp request crash/hang on Adaptec adapters

### DIFF
--- a/lib/smp_aac_io.c
+++ b/lib/smp_aac_io.c
@@ -275,7 +275,7 @@ if((aSmpResult->header.status != SMP_PASS_THRU_SUCCESS)
     }
 
 
-    memcpy(rresp->response + aSmpCmdRespOff ,&aFib->data[sizeof(SmpPassThruHeader)],aSmpResult->header.dataReceiveLength);
+    memcpy(rresp->response + aSmpCmdRespOff ,&aFib->data[sizeof(SmpPassThruHeader)],bytesToSave);
 
     aSmpCmdRespOff += bytesToSave;
     aSmpCmdRespLen -= bytesToSave;

--- a/src/smp_conf_general.c
+++ b/src/smp_conf_general.c
@@ -173,6 +173,7 @@ main(int argc, char * argv[])
     struct smp_target_obj tobj;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_conf_phy_event.c
+++ b/src/smp_conf_phy_event.c
@@ -483,6 +483,7 @@ main(int argc, char * argv[])
     smp_req[0] = SMP_FRAME_TYPE_REQ;
     smp_req[1] = SMP_FN_CONFIG_PHY_EVENT;
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_conf_route_info.c
+++ b/src/smp_conf_route_info.c
@@ -148,6 +148,7 @@ main(int argc, char * argv[])
     struct smp_target_obj tobj;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_conf_zone_man_pass.c
+++ b/src/smp_conf_zone_man_pass.c
@@ -327,6 +327,7 @@ main(int argc, char * argv[])
     memset(password, 0, sizeof password);
     memset(npassword, 0, sizeof npassword);
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_conf_zone_perm_tbl.c
+++ b/src/smp_conf_zone_perm_tbl.c
@@ -322,6 +322,7 @@ main(int argc, char * argv[])
     struct smp_target_obj tobj;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_conf_zone_phy_info.c
+++ b/src/smp_conf_zone_phy_info.c
@@ -270,6 +270,7 @@ main(int argc, char * argv[])
     smp_req[0] = SMP_FRAME_TYPE_REQ;
     smp_req[1] = SMP_FN_CONFIG_ZONE_PHY_INFO;
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_discover.c
+++ b/src/smp_discover.c
@@ -1203,6 +1203,7 @@ main(int argc, char * argv[])
     op = &opts;
     memset(op, 0, sizeof(opts));
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_discover_list.c
+++ b/src/smp_discover_list.c
@@ -1125,6 +1125,7 @@ main(int argc, char * argv[])
     op = &opts;
     memset(op, 0, sizeof(opts));
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_ena_dis_zoning.c
+++ b/src/smp_ena_dis_zoning.c
@@ -147,6 +147,7 @@ main(int argc, char * argv[])
     struct smp_target_obj tobj;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_phy_control.c
+++ b/src/smp_phy_control.c
@@ -217,6 +217,7 @@ main(int argc, char * argv[])
     struct smp_target_obj tobj;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_phy_test.c
+++ b/src/smp_phy_test.c
@@ -162,6 +162,7 @@ main(int argc, char * argv[])
     struct smp_target_obj tobj;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_rep_broadcast.c
+++ b/src/smp_rep_broadcast.c
@@ -157,6 +157,7 @@ main(int argc, char * argv[])
     struct smp_target_obj tobj;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_rep_exp_route_tbl.c
+++ b/src/smp_rep_exp_route_tbl.c
@@ -253,6 +253,7 @@ main(int argc, char * argv[])
     memset(&opts, 0, sizeof(opts));
     opts.do_num = 62;   /* maximum fitting in one response */
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_rep_manufacturer.c
+++ b/src/smp_rep_manufacturer.c
@@ -132,6 +132,7 @@ main(int argc, char * argv[])
     struct smp_target_obj tobj;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_rep_phy_err_log.c
+++ b/src/smp_rep_phy_err_log.c
@@ -135,6 +135,7 @@ main(int argc, char * argv[])
     struct smp_target_obj tobj;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_rep_phy_event.c
+++ b/src/smp_rep_phy_event.c
@@ -314,6 +314,7 @@ main(int argc, char * argv[])
     const struct pes_name_t * pnp;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_rep_phy_event_list.c
+++ b/src/smp_rep_phy_event_list.c
@@ -328,6 +328,7 @@ main(int argc, char * argv[])
     struct smp_target_obj tobj;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_rep_phy_sata.c
+++ b/src/smp_rep_phy_sata.c
@@ -143,6 +143,7 @@ main(int argc, char * argv[])
     struct smp_target_obj tobj;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_rep_route_info.c
+++ b/src/smp_rep_route_info.c
@@ -325,6 +325,7 @@ main(int argc, char * argv[])
     struct smp_target_obj tobj;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_rep_self_conf_stat.c
+++ b/src/smp_rep_self_conf_stat.c
@@ -203,6 +203,7 @@ main(int argc, char * argv[])
     struct smp_target_obj tobj;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_rep_zone_man_pass.c
+++ b/src/smp_rep_zone_man_pass.c
@@ -140,6 +140,7 @@ main(int argc, char * argv[])
     int ret = 0;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_rep_zone_perm_tbl.c
+++ b/src/smp_rep_zone_perm_tbl.c
@@ -195,6 +195,7 @@ main(int argc, char * argv[])
 
     memset(device_name, 0, sizeof device_name);
     memset(smp_resp, 0, sizeof smp_resp);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_zone_activate.c
+++ b/src/smp_zone_activate.c
@@ -129,6 +129,7 @@ main(int argc, char * argv[])
     struct smp_target_obj tobj;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_zone_lock.c
+++ b/src/smp_zone_lock.c
@@ -307,6 +307,7 @@ main(int argc, char * argv[])
     memset(password, 0, sizeof password);
     memset(device_name, 0, sizeof device_name);
     memset(smp_resp, 0, sizeof smp_resp);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_zone_unlock.c
+++ b/src/smp_zone_unlock.c
@@ -134,6 +134,7 @@ main(int argc, char * argv[])
     struct smp_target_obj tobj;
 
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 

--- a/src/smp_zoned_broadcast.c
+++ b/src/smp_zoned_broadcast.c
@@ -249,6 +249,7 @@ main(int argc, char * argv[])
 
     memset(smp_req, 0, sizeof smp_req);
     memset(device_name, 0, sizeof device_name);
+    memset(i_params, 0, sizeof i_params);
     while (1) {
         int option_index = 0;
 


### PR DESCRIPTION
Two fixes:

Correct a serious memcpy bounds error causing all > 512 byte responses to crash the request and hang the aac interface.  For example, this prevents zoning configuration requests from succeeding.

Fix a minor argument problem where checking for an unset i_params variable is branching based on stack garbage.  This is relevant when -I is intuited rather than explicit.